### PR TITLE
Update sleep in setup_localstack to actually check health endpoint

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -38,7 +38,11 @@ setup_localstack:
 	docker compose create localstack
 	docker compose start localstack
 	echo "Waiting for localstack to start..."
-	sleep 3
+	# Ping http://localhost:4566/health until we get a 200 response
+	until $$(curl --output /dev/null --silent --head --fail http://localhost:4566/health); do \
+		printf '.'; \
+		sleep 0.5; \
+	done
 	# Check that S3_ASSET_BUCKET_NAME is set
 	if [ -z ${S3_ASSET_BUCKET_NAME} ]; then \
 		echo "S3_ASSET_BUCKET_NAME is not set. Please set it and try again."; \


### PR DESCRIPTION
Actually ping localstack's health endpoint instead of just sleeping for 3 seconds and hoping that localstack is up