### PR TITLE
add try/catch for file exists error

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -82,8 +82,12 @@ async def lifespan(app: FastAPI):
     vector_store = cast(CustomPGVectorStore, vector_store)
     await vector_store.run_setup()
 
-    # Some setup is required to initialize the llama-index sentence splitter
-    split_by_sentence_tokenizer()
+    try:
+        # Some setup is required to initialize the llama-index sentence splitter
+        split_by_sentence_tokenizer()
+    except FileExistsError:
+        # Sometimes seen in deployments, should be benign.
+        logger.info("Tried to re-download NLTK files but already exists.")
     yield
     # This section is run on app shutdown
     await vector_store.close()


### PR DESCRIPTION
Fix for issue mentioned [here](https://github.com/run-llama/sec-insights/pull/66#issuecomment-1792827175).

I think what's occurring is that since we're spinning up multiple threads [here](https://github.com/run-llama/sec-insights/blob/950f88a/backend/app/main.py#L138), we're calling `split_by_sentence_tokenizer` within the `lifespan` method multiple times which are getting executed simultaneously. This seems to lead to a race condition where if one finishes before the other method calls, the other method calls raise a `FileExistsError` complaining that the file already exists. This shouldn't be a big problem given that we've actually downloaded the file that is being used internally by NLTK.