### PR TITLE
frontend hotfix for duplicated sec docs

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -12,4 +12,4 @@
 # Example:
 # SERVERVAR="foo"
 # NEXT_PUBLIC_CLIENTVAR="bar"
-NEXT_PUBLIC_BACKEND_URL=http://localhost:8000/
+NEXT_PUBLIC_BACKEND_URL=https://llama-app-backend.onrender.com/

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -12,4 +12,4 @@
 # Example:
 # SERVERVAR="foo"
 # NEXT_PUBLIC_CLIENTVAR="bar"
-NEXT_PUBLIC_BACKEND_URL=https://llama-app-backend.onrender.com/
+NEXT_PUBLIC_BACKEND_URL=http://localhost:8000/

--- a/frontend/src/api/utils/documents.tsx
+++ b/frontend/src/api/utils/documents.tsx
@@ -7,6 +7,7 @@ import _ from "lodash";
 export const fromBackendDocumentToFrontend = (
   backendDocuments: BackendDocument[]
 ) => {
+  // sort by created_at so that de-dupe filter later keeps oldest duplicate docs
   backendDocuments = _.sortBy(backendDocuments, 'created_at');
   let frontendDocs: SecDocument[] = backendDocuments
   .filter((backendDoc) => 'sec_document' in backendDoc.metadata_map)
@@ -31,6 +32,8 @@ export const fromBackendDocumentToFrontend = (
     } as SecDocument;
   });
   // de-dupe hotfix
-  frontendDocs = _.uniqBy(frontendDocs, (doc) => `${doc.ticker}-${doc.year}-${doc.quarter || ''}`)
+  const getDocDeDupeKey = (doc: SecDocument) => `${doc.ticker}-${doc.year}-${doc.quarter || ''}`;
+  frontendDocs = _.chain(frontendDocs).sortBy(getDocDeDupeKey).sortedUniqBy(getDocDeDupeKey).value();
+
   return frontendDocs;
 };

--- a/frontend/src/api/utils/documents.tsx
+++ b/frontend/src/api/utils/documents.tsx
@@ -2,12 +2,15 @@ import { MAX_NUMBER_OF_SELECTED_DOCUMENTS } from "~/hooks/useDocumentSelector";
 import { BackendDocument, BackendDocumentType } from "~/types/backend/document";
 import { SecDocument, DocumentType } from "~/types/document";
 import { documentColors } from "~/utils/colors";
+import _ from "lodash";
 
 export const fromBackendDocumentToFrontend = (
   backendDocuments: BackendDocument[]
 ) => {
-  const frontendDocs: SecDocument[] = [];
-  backendDocuments.map((backendDoc, index) => {
+  backendDocuments = _.sortBy(backendDocuments, 'created_at');
+  let frontendDocs: SecDocument[] = backendDocuments
+  .filter((backendDoc) => 'sec_document' in backendDoc.metadata_map)
+  .map((backendDoc, index) => {
     const backendDocType = backendDoc.metadata_map.sec_document.doc_type;
     const frontendDocType =
       backendDocType === BackendDocumentType.TenK
@@ -16,7 +19,7 @@ export const fromBackendDocumentToFrontend = (
 
     // we have 10 colors for 10 documents
     const colorIndex = index < 10 ? index : 0;
-    const payload = {
+    return {
       id: backendDoc.id,
       url: backendDoc.url,
       ticker: backendDoc.metadata_map.sec_document.company_ticker,
@@ -26,7 +29,8 @@ export const fromBackendDocumentToFrontend = (
       color: documentColors[colorIndex],
       quarter: backendDoc.metadata_map.sec_document.quarter || "",
     } as SecDocument;
-    frontendDocs.push(payload);
   });
+  // de-dupe hotfix
+  frontendDocs = _.uniqBy(frontendDocs, (doc) => `${doc.ticker}-${doc.year}-${doc.quarter || ''}`)
   return frontendDocs;
 };


### PR DESCRIPTION
Ran the cron job earlier today to pull some of the latest SEC filings. Seems like the newest version of the [`sec-edgar-downloader`](https://sec-edgar-downloader.readthedocs.io/en/latest/) has a different metadata structure for the filings it downloads, which means the paths the filings get stored into S3 are different than before. Hence leading to some amount of duplication in terms of the dropdown form on the landing page as seen below:

<img width="1369" alt="Screenshot 2023-11-03 at 7 32 50 PM" src="https://github.com/run-llama/sec-insights/assets/3005241/768c645c-1b87-4d8d-876b-7ab3685807b9">

This simple hotfix just does some de-duplication on the frontend to ensure we're only showing one filing from each filing period. It also does some extra filtering to ensure that we ignore any documents that aren't SEC filings. This would be useful for local development if you're trying to use the site with some custom documents already stored in the DB.